### PR TITLE
v0.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - '0.12'
+before_script:
+  - npm install gulp -g
+  - gulp tsd
+  - node ./node_modules/typescript/bin/tsc -p ./src
+  - gulp bundle-css
+after_success:
+  - sudo apt-get install python
+  - sudo ./deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ before_script:
   - npm install gulp -g
   - gulp tsd
   - node ./node_modules/typescript/bin/tsc -p ./src
+  - node ./node_modules/typescript/bin/tsc -p ./analysis
   - gulp bundle-css

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,3 @@ before_script:
   - gulp tsd
   - node ./node_modules/typescript/bin/tsc -p ./src
   - gulp bundle-css
-after_success:
-  - sudo apt-get install python
-  - sudo ./deploy.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Matthew Poegel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SemNExt-Visualizations
 
-This is a visualization tool to create Chord-Heat Map (CHeM) diagrams that
-illustrate the connections between genes for several thousand diseases and KEGG
-Pathways.
+This is a visualization tool to create Suceptibility Windows Ontological 
+Transcriptome (SWOT) Clocks that illustrate the connections between transcriptomes for several thousand available resource sets or user-defined
+lists of transcriptomes.
 
-![Autism Example](http://i.imgur.com/jCgAYV6.png?1 "CHeM Diagram generated for
+![Autism Example](http://i.imgur.com/jCgAYV6.png?1 "SWOT Clock generated for
 Autism")
 
 ## Development Instructions

--- a/analysis/clusterEnrichment.ts
+++ b/analysis/clusterEnrichment.ts
@@ -12,183 +12,191 @@ var _ = require('underscore');
 
 
 module ClusterEnrichment {
-	
-	export const clusterToStage = ['Pluripotency', 'Ectoderm', 'Neural Differentiation', 
-		'Cortical Specification', 'Early Layers', 'Upper Layers'];
-	
-	/**
-	 * Representation of the enrichment data to output for each input
-	 */
-	interface IEnrichmentObject {
-		label: string,
-		num_genes: number,
-		data: IanalysisObject[]
-	}
-	
-	/**
-	 * Representation of enrichment computations
-	 */
-	interface IanalysisObject {
-		cluster: string,
-		log_odds: number,
-		pval: number,
-	}
-	
-	/**
-	 * Run the enrichment analysis on the given input (driver function)
-	 * @param input {string[]} list of inputs to run enrichment analysis on
-	 * @param input_type {string} type of input, either "disease" or "kegg"
-	 * @callback {(x: IEnrichmentObject[]) => any} callback function to be 
-	 * 	called with the resulting analysis when the analysis is completed on
-	 * 	for all the inputs
-	 * @returns {void} 
-	 */
-	export function run(input: string[], input_type: string, callback: (x: IEnrichmentObject[]) => any): void {
-		let promises = [];
-		if (input_type === 'disease') {
-			for (var i in input) {
-				promises.push(new Promise((resolve, reject) => {
-					runDiseaseAnalysis(input[i], resolve);
-				}));
-			}
-		}
-		else if (input_type === 'kegg') {
-			for (var i in input) {
-				promises.push(new Promise((resolve, reject) => {
-					runKeggAnalysis(input[i], resolve);
-				}));
-			}
-		}
-		Promise.all(promises).then((result) => {
-			callback(_.flatten(result));
-		});
-	}
-	
-	/**
-	 * Run the cluster analysis on a given disease by search for the 
-	 * 	JSON-LD data from the API and then retreiving the list of 
-	 * 	genes in the data set to run the analysis on
-	 * @param disease {string} input disease
-	 * @param callback {(x: IEnrichmentObject[]) => any} function to 
-	 * 	call when the analysis is complete.
-	 * @returns {void}
-	 */
-	export function runDiseaseAnalysis(disease: string, callback: (x: IEnrichmentObject[]) => any): void {
-		let promises = [];
-		Semnext.findDisease(disease, (error, raw_response) => {
-			if (error) {
-				process.stdout.write(`\x1b[31m Search for ${disease} failed. \x1b[0m \n`);
-				return callback([]);
-			}
-			let response = JSON.parse(raw_response);
-			if (response.length === 0) {
-				process.stdout.write(`\x1b[31m Search for ${disease} returned no results. \x1b[0m \n`);
-				return callback([]);
-			} 
-			for (var i=0; i<response.length; i++) {
-				(function(self) {
-					promises.push(new Promise((resolve, reject) => {
-						Semnext.fetchDiseaseMatrix(self['@id'], function(raw_data) {
-							let enrichmentObj = compute(raw_data);
-							enrichmentObj.label = self.label;
-							process.stdout.write(`\x1b[32m Completed ${self.label}. \x1b[0m \n`);
-							printSignificant(enrichmentObj);
-							resolve(enrichmentObj);
-						}, function(err) {
-							process.stdout.write(`\x1b[31m Fetch for ${self.label} failed. \x1b[0m \n`);
-							resolve([]);
-						});
-					}));
-				})(response[i]);
-			}
-			Promise.all(promises).then(callback);
-		});
-	}
-	
-	/**
-	 * Run the cluster analysis on a given KEGG pathway by search for the 
-	 * 	JSON-LD data from the API and then retreiving the list of 
-	 * 	genes in the data set to run the analysis on
-	 * @param pathway {string} input KEGG pathway
-	 * @param callback {(x: IEnrichmentObject[]) => any} function to 
-	 * 	call when the analysis is complete.
-	 * @returns {void}
-	 */
-	export function runKeggAnalysis(pathway: string, callback: (IEnrichmentObject) => any): void {
-		let promises = [];
-		Semnext.findKeggPathway(pathway, (error, raw_response) => {
-			if (error) {
-				process.stdout.write(`\x1b[31m Search for ${pathway} failed. \x1b[0m \n`);
-				return callback([]);
-			}
-			let response = JSON.parse(raw_response);
-			if (response.length === 0) {
-				process.stdout.write(`\x1b[31m Search for ${pathway} returned no results. \x1b[0m \n`);
-				return callback([]);
-			}
-			for (var i=0; i<response.length; i++) {
-				(function(self) {
-					promises.push(new Promise((resolve, reject) => {
-						Semnext.fetchKeggPathwaysMatrix(self['@id'], function(raw_data) {
-							let enrichmentObj = compute(raw_data);
-							enrichmentObj.label = self.label;
-							process.stdout.write(`\x1b[32m Completed ${self.label}. \x1b[0m \n`);
-							printSignificant(enrichmentObj);
-							resolve(enrichmentObj);
-						}, function(err) {
-							process.stdout.write(`\x1b[31m Fetch for ${self.label} failed. \x1b[0m \n`);
-							resolve([]);
-						});
-					}));
-				})(response[i]);
-			}
-			Promise.all(promises).then(callback);
-		});
-	}
-	
-	/**
-	 * Crunch the numbers for the enrichment analysis for each of the six
-	 * 	clusters
-	 * @param raw_data {string[][]} raw data return from the Semnext API
-	 * @returns {IEnrichmentObject}
-	 */
-	function compute(raw_data: string[][]): IEnrichmentObject {
-		var data = Munge.munge(raw_data),
-			enrichmentObj = {
-				label: null,
-				num_genes: data.labels.length,
-				data: []
-			},
-			genes = data.labels.map(function(label, i) {
-				return {
-					label: label,
-					cluster: data.clusters[i]
-				};
-			});
-		for (var i=1; i<=6; i++) {
-			let [log_odds, pval] = Analysis.clusterEnrichment(genes, i);
-			enrichmentObj.data.push({
-				cluster: clusterToStage[i-1],
-				log_odds: log_odds,
-				pval: pval
-			});
-		}
-		return enrichmentObj;
-	}
-	
-	/**
-	 * Print the name of each cluster for which the input is enriched
-	 * @param enrichmentObj {IEnrichmentObject} enrichment object from analysis
-	 * @returns {void}
-	 */
-	function printSignificant(enrichmentObj): void {
-		for (var d in enrichmentObj.data) {
-			let cluster = enrichmentObj.data[d].cluster;
-			if (enrichmentObj.data[d].pval != null && enrichmentObj.data[d].pval <= 0.05) {
-				process.stdout.write(`\x1b[32m \t Enriched for ${cluster} \x1b[0m \n`);
-			}
-		}
-	}
+  
+  export const clusterToStage = ['Pluripotency', 'Ectoderm', 'Neural Differentiation', 
+    'Cortical Specification', 'Early Layers', 'Upper Layers'];
+  
+  /**
+   * Representation of the enrichment data to output for each input
+   */
+  interface IEnrichmentObject {
+    label: string,
+    num_genes: number,
+    data: IanalysisObject[]
+  }
+  
+  /**
+   * Representation of enrichment computations
+   */
+  interface IanalysisObject {
+    cluster: string,
+    log_odds: number,
+    pval: number,
+  }
+  
+  /**
+   * Run the enrichment analysis on the given input (driver function)
+   * @param input {string[]} list of inputs to run enrichment analysis on
+   * @param input_type {string} type of input, either "disease" or "kegg"
+   * @callback {(x: IEnrichmentObject[]) => any} callback function to be 
+   *   called with the resulting analysis when the analysis is completed on
+   *   for all the inputs
+   * @returns {void} 
+   */
+  export function run(input: string[], input_type: string, callback: (x: IEnrichmentObject[]) => any): void {
+    let promises = [];
+    if (input_type === 'disease') {
+      for (var i in input) {
+        promises.push(new Promise((resolve, reject) => {
+          runDiseaseAnalysis(input[i], resolve);
+        }));
+      }
+    }
+    else if (input_type === 'kegg') {
+      for (var i in input) {
+        promises.push(new Promise((resolve, reject) => {
+          runKeggAnalysis(input[i], resolve);
+        }));
+      }
+    }
+    Promise.all(promises).then((result) => {
+      callback(_.flatten(result));
+    });
+  }
+  
+  /**
+   * Run the cluster analysis on a given disease by search for the 
+   *   JSON-LD data from the API and then retreiving the list of 
+   *   genes in the data set to run the analysis on
+   * @param disease {string} input disease
+   * @param callback {(x: IEnrichmentObject[]) => any} function to 
+   *   call when the analysis is complete.
+   * @returns {void}
+   */
+  export function runDiseaseAnalysis(disease: string, callback: (x: IEnrichmentObject[]) => any): void {
+    let promises = [];
+    Semnext.findDisease(disease, (error, response) => {
+      if (error) {
+        process.stdout.write(`\x1b[31m Search for ${disease} failed. \x1b[0m \n`);
+        return callback([]);
+      }
+      if (response.length === 0) {
+        process.stdout.write(`\x1b[31m Search for ${disease} returned no results. \x1b[0m \n`);
+        return callback([]);
+      } 
+      for (var i=0; i<response.length; i++) {
+        (function(self) {
+          promises.push(new Promise((resolve, reject) => {
+            Semnext.fetchDiseaseMatrix(self['@id'], function(error, raw_data) {
+              if (error) {
+                process.stdout.write(`\x1b[31m Fetch for ${self.label} ` + 
+                  `failed. \x1b[0m \n`);
+                resolve([]);
+              } else {
+                let enrichmentObj = compute(raw_data);
+                enrichmentObj.label = self.label;
+                process.stdout.write(`\x1b[32m Completed ${self.label}. ` + 
+                  `\x1b[0m \n`);
+                printSignificant(enrichmentObj);
+                resolve(enrichmentObj);
+              }
+            });
+          }));
+        })(response[i]);
+      }
+      Promise.all(promises).then(callback);
+    });
+  }
+  
+  /**
+   * Run the cluster analysis on a given KEGG pathway by search for the 
+   *   JSON-LD data from the API and then retreiving the list of 
+   *   genes in the data set to run the analysis on
+   * @param pathway {string} input KEGG pathway
+   * @param callback {(x: IEnrichmentObject[]) => any} function to 
+   *   call when the analysis is complete.
+   * @returns {void}
+   */
+  export function runKeggAnalysis(pathway: string, callback: (IEnrichmentObject) => any): void {
+    let promises = [];
+    Semnext.findKeggPathway(pathway, (error, response) => {
+      if (error) {
+        process.stdout.write(`\x1b[31m Search for ${pathway} failed. \x1b[0m \n`);
+        return callback([]);
+      }
+      if (response.length === 0) {
+        process.stdout.write(`\x1b[31m Search for ${pathway} returned no results. \x1b[0m \n`);
+        return callback([]);
+      }
+      for (var i=0; i<response.length; i++) {
+        (function(self) {
+          promises.push(new Promise((resolve, reject) => {
+            Semnext.fetchKeggPathwaysMatrix(self['@id'], function(error, 
+              raw_data) 
+            {
+              if (error) {
+                let enrichmentObj = compute(raw_data);
+                enrichmentObj.label = self.label;
+                process.stdout.write(`\x1b[32m Completed ${self.label}. ` +
+                  `\x1b[0m \n`);
+                printSignificant(enrichmentObj);
+                resolve(enrichmentObj);
+              } else {
+                process.stdout.write(`\x1b[31m Fetch for ${self.label} ` + 
+                  `failed. \x1b[0m \n`);
+                resolve([]);
+              }
+            });
+          }));
+        })(response[i]);
+      }
+      Promise.all(promises).then(callback);
+    });
+  }
+  
+  /**
+   * Crunch the numbers for the enrichment analysis for each of the six
+   *   clusters
+   * @param raw_data {string[][]} raw data return from the Semnext API
+   * @returns {IEnrichmentObject}
+   */
+  function compute(raw_data: string[][]): IEnrichmentObject {
+    var data = Munge.munge(raw_data),
+      enrichmentObj = {
+        label: null,
+        num_genes: data.labels.length,
+        data: []
+      },
+      genes = data.labels.map(function(label, i) {
+        return {
+          label: label,
+          cluster: data.clusters[i]
+        };
+      });
+    for (var i=1; i<=6; i++) {
+      let [log_odds, pval] = Analysis.clusterEnrichment(genes, i);
+      enrichmentObj.data.push({
+        cluster: clusterToStage[i-1],
+        log_odds: log_odds,
+        pval: pval
+      });
+    }
+    return enrichmentObj;
+  }
+  
+  /**
+   * Print the name of each cluster for which the input is enriched
+   * @param enrichmentObj {IEnrichmentObject} enrichment object from analysis
+   * @returns {void}
+   */
+  function printSignificant(enrichmentObj): void {
+    for (var d in enrichmentObj.data) {
+      let cluster = enrichmentObj.data[d].cluster;
+      if (enrichmentObj.data[d].pval != null && enrichmentObj.data[d].pval <= 0.05) {
+        process.stdout.write(`\x1b[32m \t Enriched for ${cluster} \x1b[0m \n`);
+      }
+    }
+  }
 }
 
 export = ClusterEnrichment;

--- a/analysis/filter.ts
+++ b/analysis/filter.ts
@@ -14,10 +14,12 @@ module Filter {
     for (var i in input) {
       (function(gene) {
         promises.push(new Promise((resolve, reject) => {
-          Semnext.fetchCustomMatrix(input[i], () => {
-            resolve( gene );
-          }, () => {
-            resolve();
+          Semnext.fetchCustomMatrix(input[i], (error, data) => {
+            if (error) {
+              resolve();
+            } else {
+              resolve( gene );
+            }
           });
         }));
       })(input[i]);

--- a/definitions/campfire.d.ts
+++ b/definitions/campfire.d.ts
@@ -1,0 +1,10 @@
+/* Definitions for the extensions to Window created for the campfire
+ *
+ * Definitions by Matt Poegel (https://github.com/mpoegel)
+ */
+
+/// <reference path="../typings/d3/d3.d.ts"/>
+
+interface Window {
+  d3select: (selector: string) => d3.Selection<any>
+}

--- a/deploy
+++ b/deploy
@@ -136,7 +136,7 @@ if (__name__ == '__main__'):
   strategy = sys.argv[3]
   branch   = sys.argv[4]
   config_file     = sys.argv[5]
-
+  
   if (strategy not in dirs.keys()):
       print 'Unrecognized deployment strategy: %s' %strategy
       sys.exit(1)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+  echo { "port": "$DEPLOY_PRODUCTION_PORT" } > config.json
+  python deploy "$DEPLOY_HOSTNAME" "$DEPLOY_PASSWORD" production master config.json 
+elif [ "$TRAVIS_BRANCH" == "develop" ]; then
+  echo { "port": "$DEPLOY_DEV_PORT" } > config.json
+  python deploy "$DEPLOY_HOSTNAME" "$DEPLOY_PASSWORD" dev develop config.json 
+fi

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,18 +31,15 @@ gulp.task('tsd', function(cb) {
 
 // compile the typescript source
 gulp.task('ts', function() {
-  var ts_result = ts_project.src()
-    .pipe(ts(ts_project));
-  return ts_result.js.pipe(gulp.dest('./src'));
+  var ts_result = ts_project.src().pipe( ts(ts_project) );
+  return ts_result.js.pipe(gulp.dest('./'));
 });
 
 // clean up the generated javascript files
 gulp.task('clean:ts', function() {
   var files = [
-    './src/*.js',
-    './src/*/*.js',
-    './src/public/script/*',
-    './analysis/*.js'
+    './src/**/*.js',
+    './analysis/**/*.js'
   ]
   del(files);
   return gulp;
@@ -65,13 +62,13 @@ gulp.task('nodemon', function() {
 });
 
 gulp.task('bundle-js', ['ts'], function(done) {
-  var files = glob.sync('./src/client/script/*.js'),
+  var files = glob.sync('./src/client/script/**/*.js'),
       tasks = [];
   for (var f in files) {
     var file_path = files[f].split('/'),
         file = file_path[ file_path.length -1 ];
     var b = browserify({
-      entries: './src/client/script/' + file,
+      entries: file_path.slice(0, file_path.length-1).join('/') + '/' + file,
       debug: true
     });
     tasks.push(b.bundle()

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "CHeM-Visualizer",
-  "version": "0.3.2",
-  "description": "SemNExT Project to create Chord Heat Map Diagrams",
-  "main": "server.js",
+  "name": "swot-clock",
+  "version": "0.3.3",
+  "description": "A SemNExT Project to create Suceptibility Windows Ontological Transcriptome (SWOT) Clocks",
+  "main": "./src/server.js",
+  "scripts": {
+    "start": "node ./src/server.js",
+    "test": "node ./node_modules/mocha/bin/mocha"
+  },
   "author": "Matt Poegel",
   "contributors": [
     {
@@ -12,7 +16,7 @@
     }
   ],
   "license": "MIT",
-  "homepage": "https://semnext.tw.rpi.edu/chem",
+  "homepage": "https://semnext.tw.rpi.edu/swotclock",
   "repository": {
     "type": "git",
     "url": "https://github.com/mpoegel/SemNExT-Visualizations.git"
@@ -47,6 +51,7 @@
     "gulp-typescript": "^2.9.0",
     "gulp-uglify": "^1.4.2",
     "gulp-util": "^3.0.7",
+    "mocha": "^2.4.5",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swot-clock",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A SemNExT Project to create Suceptibility Windows Ontological Transcriptome (SWOT) Clocks",
   "main": "./src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jquery": "^2.1.4",
     "jstat": "^1.1.5",
     "less-middleware": "^2.0.1",
+    "mustache": "^2.2.1",
     "request": "^2.63.0",
     "tsd": "^0.6.5",
     "typeahead.js": "^0.11.1",

--- a/src/client/script/campfire.ts
+++ b/src/client/script/campfire.ts
@@ -67,18 +67,18 @@ namespace Campfire {
 						floorGraph = new CHeM.Graph(data, floorCanvas, {
 								onMouseOver: (d, i) => {
 									if (d.genes !== undefined) {
-										CHeM.getHeatMapClusterFader(wallHandle.d3.select('#wall'), 0.02)(d, i);
+										CHeM.getHeatMapClusterFader(wallHandle.d3select('#wall'), 0.02)(d, i);
 									}
 									else {
-										CHeM.getHeatMapFader(wallHandle.d3.select('#wall'), 0.02)(d, i);
+										CHeM.getHeatMapFader(wallHandle.d3select('#wall'), 0.02)(d, i);
 									}
 								},
 								onMouseOut: (d, i) => {
 									if (d.genes !== undefined) {
-										CHeM.getHeatMapClusterFader(wallHandle.d3.select('#wall'), 1.00)(d, i);
+										CHeM.getHeatMapClusterFader(wallHandle.d3select('#wall'), 1.00)(d, i);
 									}
 									else {
-										CHeM.getHeatMapFader(wallHandle.d3.select('#wall'), 1.00)(d, i);
+										CHeM.getHeatMapFader(wallHandle.d3select('#wall'), 1.00)(d, i);
 									}
 								}
 							})

--- a/src/client/script/helpers/graph.ts
+++ b/src/client/script/helpers/graph.ts
@@ -157,8 +157,8 @@ module CHeM {
         '#4575b4'])[(i-1)%6];
     }
     
-    static defaultHeatMapColors = ['#232323', 'green', 'red'];
-    static colorblindSafeHeatMapColors = ['#232323', 'blue', 'yellow'];
+    static defaultHeatMapColors = ['green', '#232323', 'red'];
+    static colorblindSafeHeatMapColors = ['blue', '#232323', 'yellow'];
 
     static clusterToStage = ['Pluripotency', 'Neuroectoderm',
       'Neural Differentiation', 'Cortical Specification', 'Deep Layers',
@@ -215,7 +215,7 @@ module CHeM {
       sd = Math.sqrt(sd / this.data.heatmap.length);
       this.heatmapColorScale = d3.scale.linear()
         .range(Graph.defaultHeatMapColors)
-        .domain([mu - 2 * sd, mu, mu + 2 * sd]);
+        .domain([mu - 3 * sd, mu, mu + 3 * sd]);
 
       // initialize more scales
       this.heatmapLegendScale = d3.scale.linear()

--- a/src/client/script/helpers/graph.ts
+++ b/src/client/script/helpers/graph.ts
@@ -596,10 +596,12 @@ module CHeM {
           .range([this.chord_fill(this.data.clusters[$(d).attr('source')]),
                   this.chord_fill(this.data.clusters[$(d).attr('target')])])
           .domain([0, $(d).children().length]);
-        $(d).children().each((i) => {
-          $(i).css('fill', gradient(i))
-              .css('stroke', gradient(i));
+        _.each($(d).children(), (dd,i) => {
+          d3.select(dd)
+            .style('fill', gradient(i))
+            .style('stroke', gradient(i));
         });
+        return;
       });
       d3.selectAll('g.group path')
         .style('fill', (d) => { 

--- a/src/client/script/helpers/graph.ts
+++ b/src/client/script/helpers/graph.ts
@@ -164,6 +164,8 @@ module CHeM {
       'Neural Differentiation', 'Cortical Specification', 'Deep Layers',
       'Upper Layers'];
     
+    static heatMapDayNumbers = [0, 7, 12, 19, 26, 33, 49, 63, 77];
+    
     /**
      * ACCESSORS
      */

--- a/src/client/script/helpers/ui.ts
+++ b/src/client/script/helpers/ui.ts
@@ -51,6 +51,22 @@ namespace UI {
     }, (diseaseObjs) => {
       $('.totalDiseases').text(diseaseObjs.length);
     });
+    var ua = window.navigator.userAgent,
+        IE = ua.indexOf('MSIE') > 0 || !! ua.match(/Trident.*rv\:11\./),
+        Edge = ua.indexOf('Edge') > 0;
+    /* Disable features that don't yet work in IE or Edge */
+    if ( IE || Edge ) {
+      var broken = [
+        '.chart-btn[data-action="download-png"]',
+        '.chart-btn[data-action="path-color-gradient"]'
+      ];
+      for (var i=0; i<broken.length; i++) {
+        $(broken[i])
+          .removeClass('chart-btn')
+          .addClass('disabled')
+          .attr('title', 'Feature not available in IE or Edge.');
+      }
+    }
   }
   
   /**
@@ -279,7 +295,7 @@ namespace UI {
         $btn = $btn.parent();
       }
       let action = $btn.attr('data-action'),
-        target = $btn.attr('data-target');
+          target = $btn.attr('data-target');
       switch (action) {
         // Primary options bar
         case 'highlight-none':
@@ -598,8 +614,9 @@ namespace UI {
       context.drawImage(image, 0, 0);
       var dataurl = canvasElem.toDataURL('image/png');
       var ua = window.navigator.userAgent;
-      if ( ua.indexOf('MSIE') > 0 || !! ua.match(/Trident.*rv\:11\./) ) {
-        window.open(dataurl);
+      if ( ua.indexOf('MSIE') > 0 || !! ua.match(/Trident.*rv\:11\./) ||
+           ua.indexOf('Edge') > 0 ) {
+        return;
       } else {
         let a = document.createElement('a');
         a.download = graph.getData().title + '.png';

--- a/src/client/script/helpers/ui.ts
+++ b/src/client/script/helpers/ui.ts
@@ -768,14 +768,20 @@ namespace UI {
       if (gene_data[ Math.floor(i / DAYS) ] === undefined) {
         gene_data[ Math.floor(i / DAYS) ] = {
           symbol: data[i].label,
+          cluster: data[i].cluster,
           values: [ data[i].value ]
         };
       } else {
         gene_data[ Math.floor(i / DAYS) ].values.push( data[i].value );
       }
     }
+    filestream += 'index,symbol,cluster';
+    for (let i in CHeM.Graph.heatMapDayNumbers) {
+      filestream += ',d' + CHeM.Graph.heatMapDayNumbers[i];
+    }
+    filestream += '\n';
     for (let i in gene_data) {
-      filestream += i + ',' + gene_data[i].symbol;
+      filestream += i + ',' + gene_data[i].symbol + ',' + gene_data[i].cluster
       for (let d in gene_data[i].values) {
         filestream += ',' + gene_data[i].values[d];
       }

--- a/src/client/script/helpers/ui.ts
+++ b/src/client/script/helpers/ui.ts
@@ -452,9 +452,9 @@ namespace UI {
     canvas.getSVG().selectAll('g.group, .heatmap-arc')
       .on('mouseover', CHeM.getFader(canvas.getHandle(), fade_opacity))
       .on('mouseout', CHeM.getFader(canvas.getHandle(), 1.00));
-    canvas.getSVG().selectAll('cluster-arc')
+    canvas.getSVG().selectAll('.cluster-arc')
       .on('mouseover', CHeM.getClusterFader(canvas.getHandle(), fade_opacity))
-      .on('mouseout', CHeM.getClusterFader(canvas.getHandle(), fade_opacity));
+      .on('mouseout', CHeM.getClusterFader(canvas.getHandle(), 1.00));
   }
 
   /**

--- a/src/client/script/helpers/ui.ts
+++ b/src/client/script/helpers/ui.ts
@@ -563,7 +563,10 @@ namespace UI {
     let a = document.createElement('a');
     a.download = graph.getData().title + '.svg';
     a.href = getSVGSource();
+    a.style.display = 'none';
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
   }
   
   /**
@@ -576,14 +579,17 @@ namespace UI {
     canvasElem.width = canvas.getWidth();
     canvasElem.height = canvas.getHeight();
     let context = canvasElem.getContext('2d'),
-      image = new Image;
+        image = new Image;
     image.src = getSVGSource();
     image.onload = () => {
       context.drawImage(image, 0, 0);
       let a = document.createElement('a');
       a.download = $('svg .title').text() + '.png';
       a.href = canvasElem.toDataURL('image/png');
+      a.style.display = 'none';
+      document.body.appendChild(a);
       a.click();
+      document.body.removeChild(a);
     }
   }
   

--- a/src/client/script/helpers/ui.ts
+++ b/src/client/script/helpers/ui.ts
@@ -51,6 +51,7 @@ namespace UI {
       drawCompleteGraph(diseaseObj, 'disease');
     }, (diseaseObjs) => {
       $('.totalDiseases').text(diseaseObjs.length);
+      $('#searchBox').focus();
     });
     var ua = window.navigator.userAgent,
         IE = ua.indexOf('MSIE') > 0 || !! ua.match(/Trident.*rv\:11\./),

--- a/src/client/script/helpers/ui.ts
+++ b/src/client/script/helpers/ui.ts
@@ -125,14 +125,13 @@ namespace UI {
     cb: (diseaseObjs) => any): void 
   {
     $.get(root_path + 'api/v1/list/disease')
-      .done((diseaseStr) => {
-        let diseaseObjs = JSON.parse(diseaseStr),
-          bloodhound = new Bloodhound({
-            datumTokenizer: (datum) => { return [datum.label]; },
-            queryTokenizer: Bloodhound.tokenizers.whitespace,
-            local: () => { return diseaseObjs; },
-            identify: (obj) => { return obj['@id']; },
-          });
+      .done((diseaseObjs) => {
+        let bloodhound = new Bloodhound({
+              datumTokenizer: (datum) => { return [datum.label]; },
+              queryTokenizer: Bloodhound.tokenizers.whitespace,
+              local: () => { return diseaseObjs; },
+              identify: (obj) => { return obj['@id']; },
+            });
         $input
           .typeahead('destroy')
           .typeahead({
@@ -168,14 +167,13 @@ namespace UI {
     cb: (keggObjs) => any): void 
   {
     $.get(root_path + 'api/v1/list/kegg_pathways')
-      .done((keggStr) => {
-        let keggObjs = JSON.parse(keggStr),
-          bloodhound = new Bloodhound({
-            datumTokenizer: (datum) => { return [datum.label]; },
-            queryTokenizer: Bloodhound.tokenizers.whitespace,
-            local: () => { return keggObjs; },
-            identify: (obj) => { return obj['@id']; },
-          });
+      .done((keggObjs) => {
+        let bloodhound = new Bloodhound({
+              datumTokenizer: (datum) => { return [datum.label]; },
+              queryTokenizer: Bloodhound.tokenizers.whitespace,
+              local: () => { return keggObjs; },
+              identify: (obj) => { return obj['@id']; },
+            });
         $input
           .typeahead('destroy')
           .typeahead({

--- a/src/controllers/list.ts
+++ b/src/controllers/list.ts
@@ -5,27 +5,36 @@ import _ = require('underscore');
 import semnext = require('../models/semnext');
 var router = express.Router();
 
+/**
+ * Endpoint to get the list of either diseases or KEGG Pathways that are in the
+ *  database
+ */
 router.get('/:type', (req, res) => {
-	let t = req.params.type;
-	(() => {
-		if (t === 'disease') {
-			return semnext.fetchDiseaseList;
-		}
-		else if (t === 'kegg_pathways') {
-			return semnext.fetchKeggPathwaysList;
-		}
-		else {
-			return (cb, onError) => {
-				let error = new Error('Invalid type');
-				error.name = 'Bad Request';
-				onError(error, 400);
-			}
-		}
-	})()((data) => {
-		res.send(data);
-	}, (error, code = 500) => {
-		res.status(code).send(error);
-	});
+  let t = req.params.type;
+  (() => {
+    if (t === 'disease') {
+      return semnext.fetchDiseaseList;
+    }
+    else if (t === 'kegg_pathways') {
+      return semnext.fetchKeggPathwaysList;
+    }
+    else {
+      return (cb) => {
+        let error = {
+          name: 'Bad Request',
+          message: 'Invalid type requested',
+          code: 400
+        };
+        cb(error, null);
+      }
+    }
+  })()((error, data) => {
+    if (error) {
+      res.status(error.code).send(error);
+    } else {
+      res.send(data);
+    }
+  });
 });
 
 export = router;

--- a/src/controllers/matrix.ts
+++ b/src/controllers/matrix.ts
@@ -3,32 +3,51 @@
 import express = require('express');
 import semnext = require('../models/semnext');
 import bodyParser = require('body-parser');
-var router = express.Router(),
+
+let router = express.Router(),
     jsonParser = bodyParser.json(),
     urlencodedParser = bodyParser.urlencoded({ extended: false });
 
+/**
+ * Endpoint to request the data matrix for the given disease ID
+ */
 router.post(RegExp('/disease'), urlencodedParser, (req, res) => {
-	semnext.fetchDiseaseMatrix(req.body.id, (data) => {
-		res.send(data);
-	}, (error) => {
-		res.status(500).send(error);
-	});
+  semnext.fetchDiseaseMatrix(req.body.id, (error, data) => {
+    if (error) {
+      res.status(error.code)
+         .send(error);
+    } else {
+      res.send(data);      
+    }
+  });
 });
 
+/**
+ * Endpoint to request the data matrix for the given KEGG Pathway ID
+ */
 router.post(RegExp('/kegg_pathways'), urlencodedParser, (req, res) => {
-	semnext.fetchKeggPathwaysMatrix(req.body.id, (data) => {
-		res.send(data);
-	}, (error) => {
-		res.status(500).send(error);
-	});
+  semnext.fetchKeggPathwaysMatrix(req.body.id, (error, data) => {
+    if (error) {
+      res.status(error.code)
+         .send(error);
+    } else {
+      res.send(data);
+    }
+  });
 });
 
+/**
+ * Endpoint to request the data matrix for a custom list of transcriptomes
+ */
 router.post(RegExp('/custom'), urlencodedParser, (req, res) => {
-	semnext.fetchCustomMatrix(req.body.id, (data) => {
-		res.send(data);
-	}, (error) => {
-		res.status(500).send(error);
-	});
+  semnext.fetchCustomMatrix(req.body.id, (error, data) => {
+    if (error) {
+      res.status(error.code)
+         .send(error);
+    } else {
+      res.send(data);
+    }
+  });
 });
 
 export = router;

--- a/src/models/semnext.ts
+++ b/src/models/semnext.ts
@@ -1,119 +1,250 @@
 /// <reference path="../../typings/tsd.d.ts"/>
 import request = require('request');
 import _ = require('underscore');
+import Buffer = require('buffer');
 
-interface dataCallback {
-	(data: string[][]): any;
+
+interface IErrorObj {
+  name: string;
+  message: string;
+  code: number;
+  verbose?: string;
 }
 
-interface onErrorCallback {
-	(e: Error, code?: number): any;
+interface IMatrixCallback {
+  (error: IErrorObj, data: string[][]): any;
+}
+
+interface IListCallback {
+  (error: IErrorObj, data: DiseaseObject[] | KeggPathwayObject[]): any;
 }
 
 const SemNExT_URLs = {
-	disease_matrix: 'https://semnext.tw.rpi.edu/api/v1/matrix_for_disease?disease=',
-	diseases_list: 'https://semnext.tw.rpi.edu/api/v1/list_known_diseases',
-	kegg_matrix: 'https://semnext.tw.rpi.edu/api/v1/matrix_for_kegg_pathway?pathway=',
-	kegg_list: 'https://semnext.tw.rpi.edu/api/v1/list_known_kegg_pathways',
-	custom_matrix: 'https://semnext.tw.rpi.edu/api/v1/matrix_for_genes?symbols='
+  disease_matrix: 'https://semnext.tw.rpi.edu/api/v1/matrix_for_disease?disease=',
+  diseases_list: 'https://semnext.tw.rpi.edu/api/v1/list_known_diseases',
+  kegg_matrix: 'https://semnext.tw.rpi.edu/api/v1/matrix_for_kegg_pathway?pathway=',
+  kegg_list: 'https://semnext.tw.rpi.edu/api/v1/list_known_kegg_pathways',
+  custom_matrix: 'https://semnext.tw.rpi.edu/api/v1/matrix_for_genes?symbols='
 }
 
-export function fetchDiseaseMatrix(diseaseId: string, callback: dataCallback, onError?: onErrorCallback) {
-	fetchMatrix(diseaseId, callback, SemNExT_URLs.disease_matrix, onError);
+const MAX_URI_SIZE = 8203;
+
+/**
+ * Fetch the matrix of data for the given disease. Wrapper for fetchMatrix.
+ * @param diseaseId {string} the ID of the disease to fetch
+ * @param callback {IMatrixCallback} function to call upon completion with the
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+export function fetchDiseaseMatrix(diseaseId: string, callback: IMatrixCallback)
+  :  void 
+{
+  fetchMatrix(SemNExT_URLs.disease_matrix, diseaseId, callback);
 }
 
-export function fetchKeggPathwaysMatrix(keggId: string, callback: dataCallback, onError?: onErrorCallback) {
-	fetchMatrix(keggId, callback, SemNExT_URLs.kegg_matrix, onError);
+/**
+ * Fetch the matrix of data for the given Kegg pathway. Wrapper for fetchMatrix.
+ * @param keggId {string} the ID of the KEGG pathway to fetch
+ * @param callback {IMatrixCallback} function to call upon completion with the
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+export function fetchKeggPathwaysMatrix(keggId: string, callback: 
+  IMatrixCallback):  void
+{
+  fetchMatrix(SemNExT_URLs.kegg_matrix, keggId, callback);
 }
 
-export function fetchCustomMatrix(genes: string, callback: dataCallback, onError?: onErrorCallback) {
-	fetchMatrix(genes, callback, SemNExT_URLs.custom_matrix, onError);
+/**
+ * Fetch the matrix of data for the given list of inputs. Wrapper for
+ *  fetchMatrix.
+ * @param inputs {string} comma deliminated string of input transcriptomes
+ * @param callback {IMatrixCallback} function to call upon completion with the
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+export function fetchCustomMatrix(inputs: string, callback: IMatrixCallback): 
+  void 
+{
+  fetchMatrix(SemNExT_URLs.custom_matrix, inputs, callback);
 }
 
-export function fetchMatrix(id: string, callback: dataCallback, url, onError?: onErrorCallback) {
-	request.get(url + id, function(error, response, body: string) {
-		if (error || body.search(/500 Internal Server Error/gi) != -1) {
-			let e = new Error();
-			e.name = "SemNExT API Error"
-			e.message = "Received an invalid response from the API."
-			if (onError) {
-				onError(e);
-			}
-			else {
-				console.error(e);
-			}
-		}
-		else {
-			callback(_.map(body.split('\n'), (d) => {
-				return d.split(',');
-			}));
-		}
-	});
+/**
+ * Fetch the matrix of data at the given location for the given object
+ * @param url {string} path from which to retrieve the matrix
+ * @param id {string} matrix identifier
+ * @param callback {IMatrixCallback} function to call upon completion with the 
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+function fetchMatrix(url: string, id: string, callback: IMatrixCallback): void 
+{
+  /* There apears to be a bug in nginx where it does not attach all the 
+     necessary headers when it returns 414 error for the URI being too long.
+     Since the Request module is very strict, it always expects a properly
+     formed response header, otherwise it will throw an HPE_INVALID_CONSTANT 
+     error. Therefore we must catch this error before it happens. */
+  let uri = url + id;
+  let uri_size = Buffer.Buffer.byteLength(uri, 'utf8');
+  if (uri_size > MAX_URI_SIZE) {
+    let err: IErrorObj = {
+      name: 'URI Too Long',
+      message: 'The length of the requested URI exceeds the buffer size.',
+      code: 414
+    }
+    callback(err, null);
+    return;
+  }
+  request.get(uri, function(error, response, body: string) {
+    if (error || response.statusCode >= 400) {
+      let err: IErrorObj = {
+        name: 'Internal Error',
+        message: 'Internal Error',
+        code: 500
+      };
+      if (error) {
+        console.log(error);
+        err.name = 'Internal API Error';
+        err.message = error;
+      } else {
+        err.name = 'SemNExT API Error';
+        err.message = 'Server returned status code ' + response.statusCode;
+        err.code = response.statusCode;
+        err.verbose = body;
+      }
+      callback(err, null);
+    } else {
+      callback(null, _.map(body.split('\n'), (d) => {
+        return d.split(',');
+      }));
+    }
+  });
 }
 
-export function fetchDiseaseList(callback: (data: string) => any, onError?: onErrorCallback) {
-	request.get(SemNExT_URLs.diseases_list, function(error, response, body) {
-		if (error) {
-			let e = new Error();
-			e.name = "SemNExT API Error"
-			e.message = "Failed to retrieve disease object list from the API."
-			if (onError) {
-				onError(e);
-			}
-			else {
-				console.error(e);
-			}
-		}
-		else {
-			callback(body);
-		}
-	});
+/**
+ * Fetch the entire list of diseases in the database
+ * @param callback {IListCallback} function to call upon completion with the 
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+export function fetchDiseaseList(callback: IListCallback): void 
+{
+  request.get(SemNExT_URLs.diseases_list, function(error, response, body) {
+    if (error || response.statusCode >= 400) {
+      let err: IErrorObj = {
+        name: 'Internal Error',
+        message: 'Internal Error',
+        code: 500
+      };
+      if (error) {
+        console.log(error);
+        err.name = 'Internal API Error';
+        err.message = error;
+      } else {
+        err.name = 'SemNExT API Error';
+        err.message = 'Failed to retrieve disease object list from the API. ' +
+         'Server returned status code ' + response.statusCode;
+        err.code = response.statusCode;
+        err.verbose = body;
+      }
+      callback(err, null);
+    } else {
+      callback(null, JSON.parse(body));
+    }
+  });
 }
 
-export function fetchKeggPathwaysList(callback: (data: KeggPathwayObject[]) => any, onError?: onErrorCallback) {
-	request.get(SemNExT_URLs.kegg_list, function(error, response, body) {
-		if (error) {
-			let e = new Error();
-			e.name = "SemNExT API Error"
-			e.message = "Failed to retrieve Kegg object list from the API."
-			if (onError) {
-				onError(e);
-			}
-			else {
-				console.error(e);
-			}
-		}
-		else {
-			callback(body);
-		}
-	});
+/**
+ * Fetch the entire list of KEGG pathways in the database
+ * @param callback {IListCallback} function to call upon completion with the 
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+export function fetchKeggPathwaysList(callback: IListCallback): void 
+{
+  request.get(SemNExT_URLs.kegg_list, function(error, response, body) {
+    if (error || response.statusCode >= 400) {
+      let err: IErrorObj = {
+        name: 'Internal Error',
+        message: 'Internal Error',
+        code: 500
+      };
+      if (error) {
+        console.log(error);
+        err.name = 'Internal API Error';
+        err.message = error;
+      } else {
+        err.name = 'SemNExT API Error';
+        err.message = 'Failed to retrieve KEGG Pathway object list from the '
+          'API. Server returned status code ' + response.statusCode;
+        err.code = response.statusCode;
+        err.verbose = body;
+      }
+      callback(err, null);
+    } else {
+      callback(null, JSON.parse(body));
+    }
+  });
 }
 
-export function findDisease(disease: string, callback: (e: Error, r: string) => any): void {
-	request.get(SemNExT_URLs.diseases_list + '?q=' + disease, function(error, response, body) {
-		if (error || body.search(/!DOCTYPE html/gi) != -1) {
-			let e = new Error();
-			e.name = "SemNExT API Error"
-			e.message = "Received an invalid response or error from the API."
-			callback(e, null);
-		}
-		else {
-			callback(null, body);
-		}
-	});
+/**
+ * Search for the given disease in the database. Calls the callback function
+ *  with a list of DiseaseObjects that match the query. Wrapper for findObject
+ * @param disease {string} disease search query
+ * @param callback {IListCallback} function to call upon completion with the 
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+export function findDisease(disease: string, callback: IListCallback): void {
+  findObject(SemNExT_URLs.diseases_list, disease, callback);
 }
 
-export function findKeggPathway(pathway: string, callback: (e: Error, r: string) => any): void {
-	request.get(SemNExT_URLs.kegg_list + '?q=' + pathway, function(error, response, body) {
-		if (error || body.search(/!DOCTYPE html/gi) != -1) {
-			let e = new Error();
-			e.name = "SemNExT API Error"
-			e.message = "Received an invalid response or error from the API."
-			callback(e, null);
-		}
-		else {
-			callback(null, body);
-		}
-	});
+/**
+ * Search for the given KEGG pathway in the database. Calls the callback 
+ *  function with a list of KeggPathwayObjects that match the query. Wrapper 
+ *  for findObject
+ * @param pathway {string} KEGG pathway search query
+ * @param callback {IListCallback} function to call upon completion with the 
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+export function findKeggPathway(pathway: string, callback: IListCallback): void 
+{
+  findObject(SemNExT_URLs.diseases_list, pathway, callback);  
 }
 
+/**
+ * Search for the given query at the given url endpoint.
+ * @param url {string} URL path from which to find the input
+ * @param query {string} search query 
+ * @param callback {IListCallback} function to call upon completion with the 
+ *  data on success or an error on failure
+ * @returns {void}
+ */
+function findObject(url: string, query: string, callback: IListCallback):
+  void
+{
+  let uri = url + '?q=' + query;
+  request.get(uri, function(error, response, body) {
+    if (error || response.statusCode >= 400) {
+      let err: IErrorObj = {
+        name: 'Internal Error',
+        message: 'Internal Error',
+        code: 500
+      };
+      if (error) {
+        console.log(error);
+        err.name = 'Internal API Error';
+        err.message = error;
+      } else {
+        err.name = 'SemNExT API Error';
+        err.message = 'Server returned status code ' + response.statusCode;
+        err.code = response.statusCode;
+        err.verbose = body;
+      }
+      callback(err, null);
+    } else {
+      callback(null, JSON.parse(body));
+    }
+  });
+}

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -18,22 +18,8 @@
 		<div class="container">
 
 			<div class="row expanded-settings-bar">
-
-				<div class="row">
-					<ul class="horizontal-list">
-						<li><a href="http://tw.rpi.edu/web/project/SemNExT" target="_blank">
-							Semantic Numeric Exploration Techonology (SemNExt) Project</a>
-							</li>
-						<li><a href="http://rpi.edu" target="_blank">
-							Rensselaer Polytechnic Institute, Troy, NY, USA</a></li>
-            <li><a href="https://github.com/mpoegel/SemNExT-Visualizations"
-              target="_blank">
-              Open Source on Github</a>             
-            </li>
-					</ul>
-				</div>
-
-				<div class="row">
+				
+        <div class="row">
 					<ul class="horizontal-list options-list">
 						<li class="chart-btn" data-action="change-options-bar" 
 							data-target="search-options">Search</li>
@@ -289,10 +275,25 @@
 			Semantic Data is not available for the selected data set.
 		</div>
 		<div class="geneInfo"></div>
-
-
+	</div>
+  
+  <div class="footer">
+    <div>
+      <a href="http://rpi.edu" target="_blank">
+				Rensselaer Polytechnic Institute, Troy, NY, USA</a>
+    </div>
+    <div>
+      <a href="http://tw.rpi.edu/web/project/SemNExT" target="_blank">
+			  A Semantic Numeric Exploration Techonology Project</a>
+    </div>
+    <div>
+      <a href="https://github.com/mpoegel/SemNExT-Visualizations" 
+        target="_blank">Open Source on Github</a>
+    </div>
+  </div>
+  
 	<script src="./script/main.js" charset="utf-8"></script>
-
+  
 </body>
 
 </html>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -209,72 +209,29 @@
 	</div> <!-- close HEADER -->
 
 	<div class="container content">
-		<div class="welcome-message">
-			<h2>
-				Welcome to the SWOT Clock
-			</h2>
-      <p class="subtitle">Suceptibility Windows Ontological Transcriptome 
-        Clock</p>
-			<p>
-				There are <span class="totalDiseases">#</span> diseases currently
-				in the database.
-			</p>
-			<p>
-				This is a visualization tool to create a SWOT Clock	that illustrates
-        the relationships between transcriptomes in a reference set. You can 
-        search our database of diseases or KEGG Pathways or upload your own
-        reference set.
-			</p>
+		
+		<div class="messages">
+			<div class="welcome-message">
+				<h2>
+					Welcome to the SWOT Clock
+				</h2>
+				<p class="subtitle">Suceptibility Windows Ontological Transcriptome 
+					Clock</p>
+				<p>
+					There are <span class="totalDiseases">#</span> diseases currently
+					in the database.
+				</p>
+				<p>
+					This is a visualization tool to create a SWOT Clock	that illustrates
+					the relationships between transcriptomes in a reference set. You can 
+					search our database of diseases or KEGG Pathways or upload your own
+					reference set.
+				</p>
+			</div>			
 		</div>
-		<div class="loading">
-			<i class="fa fa-5x fa-cog fa-spin"></i>
-			<p>
-				Building the SWOT Clock!
-			</p>
-		</div>
-		<div class="custom-dataset-menu">
-			<span class="chart-btn" data-action="custom-data">&times;</span>
-			<p>
-				You can create a SWOT Clock from a user-defined list of transcriptomes.
-			</p>
-			<p>
-				Data set name
-				<input type="text" name="custom-name">
-			</p>
-			<p>
-				Upload transcriptomes from a file.
-				<input type="file" name="gene-file">
-			</p>
-			<p>
-				Enter transcriptomes manually.<br>
-				<textarea name="gene-list" rows="6" cols="20"></textarea>
-				<span class="chart-btn clear-genes" data-action="clear-custom-genes">
-					&times;</span>
-			</p>
-			<p>
-				<div class="btn btn-success chart-btn"
-					data-action="create-custom">
-					Create Clock
-				</div>
-			</p>
-		</div>
-		<div class="chart-status"></div>
+		
 		<div class="chart"></div>
-		<div class="semData">
-			<dl>
-				<dt>Gene Symbol</dt><dd class="symbol"></dd>
-				<dt>Description</dt><dd class="desription"></dd>
-				<dt>Cluster</dt><dd class="cluster"></dd>
-				<dt>Present In</dt><dd class="relations"></dd>
-				<dt>Outgoing Connections</dt><dd class="outgoing"></dd>
-				<dt>Incoming Connections</dt><dd class="incoming"></dd>
-				<dt>Experimental Data</dt><dd class="days"><table class="table"></table></dd>
-			</dl>
-		</div>
-		<div class="semData-error bg-warning hidden">
-			Semantic Data is not available for the selected data set.
-		</div>
-		<div class="geneInfo"></div>
+		
 	</div>
   
   <div class="footer">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -247,7 +247,7 @@
 			</p>
 		</div>
 		<div class="custom-dataset-menu">
-			<span class="chart-btn" data-action="custom-data">&times</span>
+			<span class="chart-btn" data-action="custom-data">&times;</span>
 			<p>
 				You can create a SWOT Clock from a user-defined list of transcriptomes.
 			</p>
@@ -263,7 +263,7 @@
 				Enter transcriptomes manually.<br>
 				<textarea name="gene-list" rows="6" cols="20"></textarea>
 				<span class="chart-btn clear-genes" data-action="clear-custom-genes">
-					&times</span>
+					&times;</span>
 			</p>
 			<p>
 				<div class="btn btn-success chart-btn"

--- a/src/public/style/style.less
+++ b/src/public/style/style.less
@@ -1,92 +1,97 @@
 /* HEADER ------------------------------------------------------------- */
 .header {
-	margin-bottom: 20px;
-	background-color: #d3d3d3;
-	
-	.error-bar {
-		color: #FFF;
-		overflow: hidden;
-		padding: 10px;
-		
-		.text {
-			width: 50%;
-			margin-left: 25%;
-			padding: 10px;
-		}
-	}
+  margin-bottom: 20px;
+  background-color: #d3d3d3;
+  
+  .error-bar {
+    color: #FFF;
+    overflow: hidden;
+    padding: 10px;
+    
+    .text {
+      width: 50%;
+      margin-left: 25%;
+      padding: 10px;
+    }
+  }
 }
 
 .settings-bar {
-	height: 60px;
-	padding: 15px;
+  height: 60px;
+  padding: 15px;
 }
 
 .horizontal-list {
-	list-style-type: none;
-	
-	li {
-		float: left;
-		padding-right: 20px;
-		padding-bottom: 10px;
-	}
+  list-style-type: none;
+  
+  li {
+    float: left;
+    padding-right: 20px;
+    padding-bottom: 10px;
+  }
 }
 
 .expanded-settings-bar {
-	display: none;
-	
-	.options-list li:hover {
-		cursor: pointer;
-	}
-	.selected {
-		font-weight: bold;
-	}
+  display: none;
+  padding-top: 10px;
+  
+  .options-list li:hover {
+    cursor: pointer;
+  }
+  .selected {
+    font-weight: bold;
+  }
 }
 
 .active-options-bar {
-	padding-left: 40px; 
-	
-	.option {
-		display: none;
-	}
-	
-	.download-btn {
-		margin-top: 5px;
-	}
-	
-	.cluster-enrichment {
-		border-spacing: 20px;
-		column-gap: 20px;
-		
-		td, th {
-			padding: 1px 8px;
-			text-align: center;
-		}
-	}
+  padding-left: 40px; 
+  
+  .option {
+    display: none;
+  }
+  
+  .download-btn {
+    margin-top: 5px;
+  }
+  
+  .cluster-enrichment {
+    border-spacing: 20px;
+    column-gap: 20px;
+    
+    td, th {
+      padding: 1px 8px;
+      text-align: center;
+    }
+  }
 }
 
 /* CONTENT  ----------------------------------------------------------------- */
 html, body {
-	height: 100%;
+  height: 100%;
+}
+
+.content {
+  min-height: calc(~"100vh - 60px - 70px");
 }
 
 .chart-status  {
-	text-align: center;
-	display: none;
-	margin: auto;
-	width: 600px;
-	height: 300px;
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
+  text-align: center;
+  display: none;
+  margin: auto;
+  width: 600px;
+  height: 300px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .welcome-message {
-	margin: 100px auto;
-	text-align: center;
-	width: 600px;
-	height: 300px;
+  margin: 100px auto;
+  text-align: center;
+  width: 600px;
+  height: 300px;
   
   .subtitle {
     color: #676767;
@@ -96,96 +101,96 @@ html, body {
 }
 
 .totalDiseases {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 .chart {
-	text-align: center;
+  text-align: center;
   display: none;
 }
 
 .loading {
-	display: none;
-	text-align: center;
-	margin: auto;
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	width: 600px;
-	height: 300px;
+  display: none;
+  text-align: center;
+  margin: auto;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 600px;
+  height: 300px;
 }
 
 .loading p {
-	font-size: 18px;
+  font-size: 18px;
 }
 
 .custom-dataset-menu {
-	display: none;
-	background-color: #FFFFFF;
-	border: 1px solid #777;
-	-webkit-border-radius: 10px;
-		 -moz-border-radius: 10px;
-					border-radius: 10px;
-	-webkit-box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
-		 -moz-box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
-					box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
-	padding: 20px;
-	text-align: center;
-	margin: auto;
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	width: 600px;
-	height: 350px;
+  display: none;
+  background-color: #FFFFFF;
+  border: 1px solid #777;
+  -webkit-border-radius: 10px;
+     -moz-border-radius: 10px;
+          border-radius: 10px;
+  -webkit-box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
+     -moz-box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
+          box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
+  padding: 20px;
+  text-align: center;
+  margin: auto;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 600px;
+  height: 350px;
 }
 
 .custom-dataset-menu span[data-action="custom-data"] {
-	position: absolute;
-	left: 95%;
-	top: 2%;
-	color: #932;
-	font-size: 24px;
-	cursor: pointer;
+  position: absolute;
+  left: 95%;
+  top: 2%;
+  color: #932;
+  font-size: 24px;
+  cursor: pointer;
 }
 
 .custom-dataset-menu p:first-child {
-	font-size: 18px;
+  font-size: 18px;
 }
 
 .custom-dataset-menu .clear-genes {
-	vertical-align: top;
-	font-size: 18px;
-	cursor: pointer;
+  vertical-align: top;
+  font-size: 18px;
+  cursor: pointer;
 }
 
 .custom-dataset-menu input {
-	margin: auto;
+  margin: auto;
 }
 
 .semData {
-	display: none;
+  display: none;
 }
 
 .semData-error {
-	padding: 10px;
-	margin-bottom: 20px;
+  padding: 10px;
+  margin-bottom: 20px;
 }
 
 .geneInfo {
-	z-index: 9999;
-	display: none;
-	position: absolute;
-	border: 1px solid #CCC;
-	background: #FFF;
-	color: #333;
-	-webkit-border-radius: 5px;
-		 -moz-border-radius: 5px;
-					border-radius: 5px;
-	max-width:200px;
+  z-index: 9999;
+  display: none;
+  position: absolute;
+  border: 1px solid #CCC;
+  background: #FFF;
+  color: #333;
+  -webkit-border-radius: 5px;
+     -moz-border-radius: 5px;
+          border-radius: 5px;
+  max-width:200px;
 }
 
 /* TYPEAHEAD ---------------------------------------------------------------- */
@@ -227,4 +232,23 @@ html, body {
 
 .tt-suggestion p {
   margin: 0;
+}
+
+/* FOOTER ------------------------------------------------------------------- */
+.footer {
+  display: -webkit-flex;
+  display:     -ms-flex;
+  display:         flex;
+  flex-wrap: wrap;
+  height: 40px;
+  
+  div {
+    flex: auto;
+    flex-basis: 33%;
+    height: 25px;
+    text-align: center;
+    a {
+      margin-left: 5px;
+    }
+  }
 }

--- a/src/public/style/style.less
+++ b/src/public/style/style.less
@@ -110,40 +110,33 @@ html, body {
 }
 
 .loading {
-  display: none;
   text-align: center;
-  margin: auto;
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  width: 600px;
-  height: 300px;
+  margin: 100px 0;
+  width: 100%;
 }
 
 .loading p {
   font-size: 18px;
 }
 
+.data-table { 
+  margin: 20px auto;
+  border-collapse: separate;
+  border-spacing: 50px 1px;
+    
+  td {
+    padding: 2px 0;
+  }
+  
+  tr:last-child td:first-child {
+    font-weight: bold;
+  }
+}
+
 .custom-dataset-menu {
-  display: none;
-  background-color: #FFFFFF;
-  border: 1px solid #777;
-  -webkit-border-radius: 10px;
-     -moz-border-radius: 10px;
-          border-radius: 10px;
-  -webkit-box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
-     -moz-box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
-          box-shadow: 10px 10px 30px 0px rgba(0,0,0,0.25);
   padding: 20px;
   text-align: center;
   margin: auto;
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
   width: 600px;
   height: 350px;
 }

--- a/src/public/templates/custom_menu.mst
+++ b/src/public/templates/custom_menu.mst
@@ -1,0 +1,25 @@
+<div class="custom-dataset-menu">
+  <p>
+    You can create a SWOT Clock from a user-defined list of transcriptomes.
+  </p>
+  <p>
+    Data set name
+    <input type="text" name="custom-name">
+  </p>
+  <p>
+    Upload transcriptomes from a file.
+    <input type="file" name="gene-file">
+  </p>
+  <p>
+    Enter transcriptomes manually.<br>
+    <textarea name="gene-list" rows="6" cols="20"></textarea>
+    <span class="chart-btn clear-genes" data-action="clear-custom-genes">
+      &times;</span>
+  </p>
+  <p>
+    <div class="btn btn-success chart-btn"
+      data-action="create-custom">
+      Create Clock
+    </div>
+  </p>
+</div>

--- a/src/public/templates/data_table.mst
+++ b/src/public/templates/data_table.mst
@@ -1,0 +1,20 @@
+<table class="data-table">
+  <thead>
+    <th>Symbol</th>
+    <th>Cluster</th>
+  </thead>
+  <tbody>
+    {{# data }}
+      <tr>
+        <td>{{ symbol }}</td>
+        <td>{{ cluster }}</td>
+      </tr>
+    {{/ data }}
+    <tr>
+      <td>Total</td>
+      <td>{{ total }} / {{ minimum }}</td>
+    </tr>
+  </tbody>
+</table>
+
+

--- a/src/public/templates/loading.mst
+++ b/src/public/templates/loading.mst
@@ -1,0 +1,6 @@
+<div class="loading">
+  <i class="fa fa-5x fa-cog fa-spin"></i>
+  <p>
+    Building the SWOT Clock!
+  </p>
+</div>

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,9 @@ app.use(lessMiddleware(
   __dirname + '/public',
   { force: true }
 ));
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+  strict: false
+}));
 // serve the contents of the /public directory at the root
 app.use('/', express.static(__dirname + '/public'));
 // load the route controllers

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -24,6 +24,7 @@
         "./client/script/helpers/graph.ts",
         "./client/script/helpers/ui.ts",
         "./server.ts",
+        "./../definitions/campfire.d.ts",
         "./../definitions/jStat.d.ts",
         "./../definitions/lib_ext.d.ts",
         "./../definitions/semnext.d.ts",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,5 @@
+/**
+ * test.js
+ * 
+ * Unit tests defined using Mocha
+ */

--- a/tsd.json
+++ b/tsd.json
@@ -6,52 +6,52 @@
   "bundle": "typings/tsd.d.ts",
   "installed": {
     "jquery/jquery.d.ts": {
-      "commit": "066819c65ff561ca109955e0b725c253e243f0a2"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "d3/d3.d.ts": {
-      "commit": "066819c65ff561ca109955e0b725c253e243f0a2"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "bootstrap/bootstrap.d.ts": {
-      "commit": "066819c65ff561ca109955e0b725c253e243f0a2"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "underscore/underscore.d.ts": {
-      "commit": "066819c65ff561ca109955e0b725c253e243f0a2"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "node/node.d.ts": {
-      "commit": "a44529fcb1e1cdc0355e71c42a6048de99b57c34"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "express/express.d.ts": {
-      "commit": "a44529fcb1e1cdc0355e71c42a6048de99b57c34"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "serve-static/serve-static.d.ts": {
-      "commit": "a44529fcb1e1cdc0355e71c42a6048de99b57c34"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "mime/mime.d.ts": {
-      "commit": "a44529fcb1e1cdc0355e71c42a6048de99b57c34"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "request/request.d.ts": {
-      "commit": "68d9d43ce884e1ffb6ec0daf4ee7be9392c5b7bc"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "form-data/form-data.d.ts": {
-      "commit": "68d9d43ce884e1ffb6ec0daf4ee7be9392c5b7bc"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "less/less.d.ts": {
-      "commit": "44cbde48eecd1918ed54b3be49a9752688b6c65a"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "less-middleware/less-middleware.d.ts": {
-      "commit": "44cbde48eecd1918ed54b3be49a9752688b6c65a"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "velocity-animate/velocity-animate.d.ts": {
-      "commit": "62eedc3121a5e28c50473d2e4a9cefbcb9c3957f"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "es6-promise/es6-promise.d.ts": {
-      "commit": "961b76f37bdfcff459cab9ed9fd3f204f0633d5e"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "body-parser/body-parser.d.ts": {
-      "commit": "a44529fcb1e1cdc0355e71c42a6048de99b57c34"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     },
     "express-serve-static-core/express-serve-static-core.d.ts": {
-      "commit": "a44529fcb1e1cdc0355e71c42a6048de99b57c34"
+      "commit": "d99f6bb17b9b8a30551da3a387b0ca4c28f5cb06"
     }
   }
 }


### PR DESCRIPTION
* added MIT license
* added unit test framework
* added Travis CI to compile the TypeScript and run any unit tests
* fixed download procedure
  - more robust than before
  - fixed download bugs in FireFox, IE, and Edge
  - PNG download still fails in IE and Edge
* fixed bugs in gulpfile
* changed heat map color order to go black-green-red
* changed heat map range to be +/- 3 times the standard deviation
* fixed color settings not being retained when drawing a new clock
* moved meta links from the header to the footer
* added header and cluster information to the heat map download
* fixed hover highlighting on cluster bands
* added Mustache templates
* added table of transcriptomes that displays instead of a clock when not enough are received
* fixed recoloring of chord gradients bug
* made search box focused on load
* changed `fetchMatrix` to use a `POST` request to the semnext API to accommodate long lists of transcriptomes